### PR TITLE
Resolve serverless config syntax issues.

### DIFF
--- a/ConfigurationApi/serverless.yml
+++ b/ConfigurationApi/serverless.yml
@@ -58,7 +58,7 @@ resources:
         GroupName: ${self:service}-${self:provider.stage}-sg
         GroupDescription: Allow all outbound traffic
         SecurityGroupEgress:
-          - IpProtocol: "-1"
+          - IpProtocol: -1
             CidrIp: 0.0.0.0/0
         VpcId: ${self:custom.vpcId.${opt:stage}}
 

--- a/ConfigurationApi/serverless.yml
+++ b/ConfigurationApi/serverless.yml
@@ -123,8 +123,8 @@ resources:
                     - "s3:GetObject"
                     - "s3:ListBucket"
                   Resource:
-                    - 'Fn::Sub': 'arn:aws:s3:::${ssm:/configuration-api/${self:provider.stage}/bucket-name}'
-                    - 'Fn::Sub': 'arn:aws:s3:::${ssm:/configuration-api/${self:provider.stage}/bucket-name}/*'
+                    - 'arn:aws:s3:::${ssm:/configuration-api/${self:provider.stage}/bucket-name}'
+                    - 'arn:aws:s3:::${ssm:/configuration-api/${self:provider.stage}/bucket-name}/*'
 
 custom:
   associateWaf:

--- a/ConfigurationApi/serverless.yml
+++ b/ConfigurationApi/serverless.yml
@@ -6,11 +6,7 @@ provider:
   tracing:
     lambda: true
     apiGateway: true
-  vpc:
-    securityGroupIds:
-      - ${self:custom.vpc.${opt:stage}.securityGroupIds}
-    subnetIds:
-      - ${self:custom.vpc.${opt:stage}.subnetIds}
+  vpc: ${self:custom.vpc.${opt:stage}}
   stage: ${opt:stage}
   region: eu-west-2
 


### PR DESCRIPTION
# What:
 - Pass the VPC parameters as an sg and subnets pair.
 - Drop the substitute function.
 - Change protocol value back to int.

# Why:
 - VPC parameters get the `[!] Invalid configuration encountered  at 'provider.vpc.subnetIds.0': unsupported configuration format` error. Likely due to passed subnets list being passed as index keys object.
 - To avoid the as many CREATE, UPDATE, DELETE stack resource changes as possible to simplify rollback.

# Notes:

| Serverless failure |
| --- |
| ![image](https://github.com/user-attachments/assets/78b733e9-2d3e-4dbf-a655-76de76a2e539) |