### PR TITLE
Make serverless skip managing the authorizer that sits on `DevelopmentAPIs` account.

### DIFF
--- a/ConfigurationApi/serverless.yml
+++ b/ConfigurationApi/serverless.yml
@@ -34,6 +34,7 @@ functions:
             type: request
             resultTtlInSeconds: 0
             identitySource: method.request.header.Authorization
+            managedExternally: true
           cors:
             origin: '*'
             headers:


### PR DESCRIPTION
# What:
 - Make serverless skip the management of the lambda authorizer that's configured on `DevelopmentAPIs` account.

# Why:
 - Stack fails to deploy because it tries to manage specified ARN of a resource in non-`Housing-Development` account

# Screnshots:

| Cross account serverless error | Cross account CloudFormation error |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/4aeb7980-eb97-49b5-9344-d78bf04dcb19) | ![image](https://github.com/user-attachments/assets/dcc471bb-6a89-4244-8ddf-cf342fc31634) |

# Notes:
 - CF error: `✖ ServerlessError3: Stack:arn:aws:cloudformation:eu-west-2:364864573329:stack/configuration-api-development/087cb3d0-e939-11eb-8d25-02b03217927c is in UPDATE_ROLLBACK_COMPLETE_CLEANUP_IN_PROGRESS state and can not be updated.`