### PR TITLE
Add feature branch CCI workflow with Terraform preview steps.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -206,6 +206,36 @@ workflows:
               ignore:
                 - master
                 - release
+      - assume-role-development:
+          context: api-assume-role-housing-development-context
+          filters:
+            branches:
+              ignore:
+                - master
+                - release
+      - preview-development-terraform:
+          requires:
+            - assume-role-development
+      - assume-role-staging:
+          context: api-assume-role-housing-staging-context
+          filters:
+            branches:
+              ignore:
+                - master
+                - release
+      - preview-staging-terraform:
+          requires:
+            - assume-role-staging
+      - assume-role-production:
+          context: api-assume-role-housing-production-context
+          filters:
+            branches:
+              ignore:
+                - master
+                - release
+      - preview-production-terraform:
+          requires:
+            - assume-role-production
   development:
     jobs:
       - check-code-formatting:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -158,6 +158,24 @@ jobs:
           stage: "production"
 
 workflows:
+  feature:
+    jobs:
+      - check-code-formatting:
+          context: api-nuget-token-context
+          filters:
+            branches:
+              ignore:
+                - master
+                - release
+      - build-and-test:
+          context:
+            - api-nuget-token-context
+            - SonarCloud
+          filters:
+            branches:
+              ignore:
+                - master
+                - release
   development:
     jobs:
       - check-code-formatting:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -158,7 +158,7 @@ jobs:
           stage: "production"
 
 workflows:
-  check-and-deploy-development:
+  development:
     jobs:
       - check-code-formatting:
           context: api-nuget-token-context
@@ -194,7 +194,7 @@ workflows:
           filters:
             branches:
               only: master
-  check-and-deploy-staging-and-production:
+  staging-and-production:
       jobs:
       - check-code-formatting:
           context: api-nuget-token-context

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -162,10 +162,16 @@ workflows:
     jobs:
       - check-code-formatting:
           context: api-nuget-token-context
+          filters:
+            branches:
+              only: master
       - build-and-test:
           context:
             - api-nuget-token-context
             - SonarCloud
+          filters:
+            branches:
+              only: master
       - assume-role-development:
           context: api-assume-role-housing-development-context
           requires:
@@ -192,6 +198,9 @@ workflows:
       jobs:
       - check-code-formatting:
           context: api-nuget-token-context
+          filters:
+            branches:
+              only: release
       - build-and-test:
           context:
             - api-nuget-token-context

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,6 +58,21 @@ commands:
           command: |
             cd ./terraform/<<parameters.environment>>/
             terraform apply -auto-approve
+  terraform-preview:
+    description: "Gives a preview for Terraform configuration changes."
+    parameters:
+      environment:
+        type: string
+    steps:
+      - *attach_workspace
+      - checkout
+      - run:
+          command: |
+            cd ./terraform/<<parameters.environment>>/
+            terraform get -update=true
+            terraform init
+            terraform plan
+          name: terraform preview
   deploy-lambda:
     description: "Deploys API via Serverless"
     parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -156,6 +156,21 @@ jobs:
     steps:
       - terraform-init-then-apply:
           environment: "production"
+  preview-development-terraform:
+    executor: docker-terraform
+    steps:
+      - terraform-preview:
+          environment: "development"
+  preview-staging-terraform:
+    executor: docker-terraform
+    steps:
+      - terraform-preview:
+          environment: "staging"
+  preview-production-terraform:
+    executor: docker-terraform
+    steps:
+      - terraform-preview:
+          environment: "production"
   deploy-to-development:
     executor: docker-dotnet
     steps:


### PR DESCRIPTION
# What:
 - Add feature branch workflow.
 - Add Terraform preview steps to the feature branch workflow.
 - Make CircleCI workflow names clearer. 

# Why:
 - To be able to see TF changes in advance to prevent accidental resource modification, downgrades, or destruction upon releasing new changes whilst having unforeseen Terraform drift.

# Notes:
 - Renamed workflows to make it easier to see which environment they represent. The check and deploy name portion is implied from the environment name.