### PR TITLE
Fix CORS origins

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -218,6 +218,12 @@ workflows:
               ignore:
                 - master
                 - release
+      - deploy-to-development:
+          context:
+            - api-nuget-token-context
+            - "Serverless Framework"
+          requires:
+            - assume-role-development
       - preview-development-terraform:
           requires:
             - assume-role-development

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -218,12 +218,6 @@ workflows:
               ignore:
                 - master
                 - release
-      - deploy-to-development:
-          context:
-            - api-nuget-token-context
-            - "Serverless Framework"
-          requires:
-            - assume-role-development
       - preview-development-terraform:
           requires:
             - assume-role-development

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,15 +1,13 @@
 version: 2.1
 
 orbs:
-  aws-ecr: circleci/aws-ecr@3.0.0
-  aws-cli: circleci/aws-cli@0.1.9
   aws_assume_role: lbh-hackit/aws_assume_role@0.1.0
   sonarcloud: sonarsource/sonarcloud@2.0.0
 
 executors:
   docker-python:
     docker:
-      - image: circleci/python:3.7
+      - image: cimg/python:3.12
   docker-terraform:
     docker:
       - image: "hashicorp/terraform:light"
@@ -122,10 +120,10 @@ jobs:
       - setup_remote_docker
       - run:
           name: build
-          command: docker-compose build configuration-api-test
+          command: docker compose build configuration-api-test
       - run:
           name: Run tests
-          command: docker-compose run configuration-api-test
+          command: docker compose run configuration-api-test
       - run:
           name: Prepare the report
           command: |

--- a/ConfigurationApi/Startup.cs
+++ b/ConfigurationApi/Startup.cs
@@ -150,6 +150,7 @@ namespace ConfigurationApi
         public static void Configure(IApplicationBuilder app, IWebHostEnvironment env, ILogger<Startup> logger)
         {
             app.UseCors(builder => builder
+                .AllowAnyOrigin()
                 .AllowAnyHeader()
                 .AllowAnyMethod()
                 .WithExposedHeaders("x-correlation-id"));

--- a/Makefile
+++ b/Makefile
@@ -1,22 +1,22 @@
 .PHONY: setup
 setup:
-	docker-compose build
+	docker compose build
 
 .PHONY: build
 build:
-	docker-compose build base-api
+	docker compose build base-api
 
 .PHONY: serve
 serve:
-	docker-compose build base-api && docker-compose up base-api
+	docker compose build base-api && docker compose up base-api
 
 .PHONY: shell
 shell:
-	docker-compose run base-api bash
+	docker compose run base-api bash
 
 .PHONY: test
 test:
-	docker-compose up test-database & docker-compose build base-api-test && docker-compose up base-api-test
+	docker compose up test-database & docker compose build base-api-test && docker compose up base-api-test
 
 .PHONY: lint
 lint:
@@ -29,4 +29,4 @@ restart-db:
 	docker stop $$(docker ps -q --filter ancestor=test-database -a)
 	-docker rm $$(docker ps -q --filter ancestor=test-database -a)
 	docker rmi test-database
-	docker-compose up -d test-database
+	docker compose up -d test-database


### PR DESCRIPTION
[HPT-654](https://hackney.atlassian.net/browse/HPT-654) CORS issues with configuration API

This is caused by a CORS issue with the Configuration API. Network requests for this API were returning 200 with a MissingAllowOriginHeader on MMH which prevents our client code from accessing the data.

The reason a lot of users aren't getting this issue is because the browser is storing the configuration data in "Local Storage" which persists even when we clear cache. It uses this when the request fails. That's also why the issue happens in incognito mode because the data isn't available there until a successful configuration API request.

Solution: Fix the CORS settings on the Configuration API to allow any origin.