### PR TITLE
Update staging lambda authorizer

### DIFF
--- a/ConfigurationApi/serverless.yml
+++ b/ConfigurationApi/serverless.yml
@@ -30,7 +30,7 @@ functions:
           path: /{proxy+}
           method: ANY
           authorizer:
-            arn: ${ssm:/api-authenticator/${self:provider.stage}/arn}
+            arn: ${self:custom.authorizerArns.${opt:stage}}
             type: request
             resultTtlInSeconds: 0
             identitySource: method.request.header.Authorization
@@ -128,6 +128,11 @@ resources:
                     - 'arn:aws:s3:::${ssm:/configuration-api/${self:provider.stage}/bucket-name}/*'
 
 custom:
+  authorizerArns:
+    development: arn:aws:lambda:eu-west-2:859159924354:function:api-auth-verify-token-development-apiauthverifytoken
+    staging:     arn:aws:lambda:eu-west-2:715003523189:function:api-auth-verify-token-new-staging-apiauthverifytokennew
+    production:  arn:aws:lambda:eu-west-2:153306643385:function:api-auth-verify-token-production-apiauthverifytoken
+    
   associateWaf:
     name: Platform_APIs_Web_ACL
     version: V2


### PR DESCRIPTION
Update staging lambda authorizer

- Hardcode authorizer ARNs in serverless, preventing any unintended changes via parameter store
- Update staging authorizer to the new version