### PR TITLE
Bump JWT core to 1.87.0 for Cognito support

### DIFF
--- a/ConfigurationApi/ConfigurationApi.csproj
+++ b/ConfigurationApi/ConfigurationApi.csproj
@@ -34,6 +34,7 @@
     <PackageReference Include="AWSXRayRecorder.Handlers.AwsSdk" Version="2.13.0" />
     <PackageReference Include="FluentValidation" Version="10.3.0" />
     <PackageReference Include="FluentValidation.AspNetCore" Version="10.3.0" />
+    <PackageReference Include="Hackney.Core.JWT" Version="1.87.0" />
     <PackageReference Include="Hackney.Core.Logging" Version="1.30.0" />
     <PackageReference Include="Hackney.Core.Middleware" Version="1.30.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="5.0.0" />

--- a/ConfigurationApi/ConfigurationApi.csproj
+++ b/ConfigurationApi/ConfigurationApi.csproj
@@ -34,7 +34,6 @@
     <PackageReference Include="AWSXRayRecorder.Handlers.AwsSdk" Version="2.13.0" />
     <PackageReference Include="FluentValidation" Version="10.3.0" />
     <PackageReference Include="FluentValidation.AspNetCore" Version="10.3.0" />
-    <PackageReference Include="Hackney.Core.JWT" Version="1.30.0" />
     <PackageReference Include="Hackney.Core.Logging" Version="1.30.0" />
     <PackageReference Include="Hackney.Core.Middleware" Version="1.30.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="5.0.0" />

--- a/ConfigurationApi/Startup.cs
+++ b/ConfigurationApi/Startup.cs
@@ -6,6 +6,7 @@ using ConfigurationApi.V1.Infrastructure;
 using ConfigurationApi.V1.UseCase;
 using ConfigurationApi.Versioning;
 using FluentValidation.AspNetCore;
+using Hackney.Core.JWT;
 using Hackney.Core.Logging;
 using Hackney.Core.Middleware.CorrelationId;
 using Hackney.Core.Middleware.Exception;
@@ -128,6 +129,10 @@ namespace ConfigurationApi
 
             services.ConfigureLambdaLogging(Configuration);
             services.AddLogCallAspect();
+            // Most opaque design - despite appearing to be unused within this repo
+            // (no direct references, nor Authorization core is used), this is actually
+            // used by the Logging core to print user email.
+            services.AddTokenFactory();
             services.ConfigureS3(Configuration);
 
             RegisterGateways(services);

--- a/ConfigurationApi/Startup.cs
+++ b/ConfigurationApi/Startup.cs
@@ -131,7 +131,7 @@ namespace ConfigurationApi
             services.AddLogCallAspect();
             // Most opaque design - despite appearing to be unused within this repo
             // (no direct references, nor Authorization core is used), this is actually
-            // used by the Logging core to print user email.
+            // used by the Logging Middleware core to print user email.
             services.AddTokenFactory();
             services.ConfigureS3(Configuration);
 

--- a/ConfigurationApi/Startup.cs
+++ b/ConfigurationApi/Startup.cs
@@ -6,7 +6,6 @@ using ConfigurationApi.V1.Infrastructure;
 using ConfigurationApi.V1.UseCase;
 using ConfigurationApi.Versioning;
 using FluentValidation.AspNetCore;
-using Hackney.Core.JWT;
 using Hackney.Core.Logging;
 using Hackney.Core.Middleware.CorrelationId;
 using Hackney.Core.Middleware.Exception;
@@ -129,7 +128,6 @@ namespace ConfigurationApi
 
             services.ConfigureLambdaLogging(Configuration);
             services.AddLogCallAspect();
-            services.AddTokenFactory();
             services.ConfigureS3(Configuration);
 
             RegisterGateways(services);


### PR DESCRIPTION
# What:
 - Update the `Hackney.Core.JWT` package multiple versions up _(1.30 -> ... -> 1.87)_.

# Why:
 - To get the latest version of the `ITokenFactory` implementation that adds support for the Cognito token schema.

# Notes:
 - The versions in between have no consequence as the only thing the JWT package is used here for is to inject TokenFactory so that logger could use it to extract user email. The Token schema for email hasn't changed. In fact, the only thing that changed about Token schema is Nbf, Exp, and Iat field types being changed from int to long.
 - What changes does latest _(v1.87.0)_ JWT intoduce? See PR: https://github.com/LBHackney-IT/lbh-core/pull/68.
 - **These changes do not require immediate deployment**, they merely need to be present within the repo's main branch. This is so those changes would already be there for when anyone would introduce new changes attempting to access Google groups from the token. Without this JWT version bump, any attempted access of Groups within the token would make the API wouldn't fall over.
